### PR TITLE
Fix sortByYearAndMonth - ITechSpeaking objects

### DIFF
--- a/src/app/pages/technology-talks/technology-talks.component.ts
+++ b/src/app/pages/technology-talks/technology-talks.component.ts
@@ -26,9 +26,36 @@ export class TechnologyTalksComponent {
 
   getTechSpeakingsData() {
     this.apiService.getTechSpeakingInfo().subscribe((res: any) => {
-      this.techSpeaking = Object.values(res) as ITechSpeaking[];
+      const techSpeakingData = Object.values(res) as ITechSpeaking[];
+      this.techSpeaking = this.sortByYearAndMonth(techSpeakingData);
     });
   }
+  
+  /**
+   * sortByYearAndMonth - Sorts the data by year and month
+   * @param data - Array of ITechSpeaking objects
+   * @returns 
+   */
+  sortByYearAndMonth(data: ITechSpeaking[]): ITechSpeaking[] {
+    const monthOrder: { [key: string]: number } = {
+      Jan: 1, Feb: 2, Mar: 3, Apr: 4, May: 5, Jun: 6,
+      Jul: 7, Aug: 8, Sep: 9, Oct: 10, Nov: 11, Dec: 12
+    };
+  
+    return data.sort((a: any, b: any) => {
+      const [monthA, yearA] = a.date.split(" ");
+      const [monthB, yearB] = b.date.split(" ");
+      const numYearA = parseInt(yearA, 10);
+      const numYearB = parseInt(yearB, 10);
+  
+      if (numYearA !== numYearB) {
+        return numYearB - numYearA; // Sort by year first (latest first)
+      } else {
+        return monthOrder[monthB] - monthOrder[monthA]; // Then by month (latest first)
+      }
+    });
+  }
+  
 
   getHashTags(technologies: string): string[] {
     const wordsArray = technologies.split(" | ");


### PR DESCRIPTION
`getTechSpeakingsData()`

- Calls the API and converts the response to an array.
- Passes the data to sortByYearAndMonth().
- sortByYearAndMonth()

- Extracts the month and year from the date field.
- Sorts by year first (newest first).
- If the years are the same, it sorts by month (newest first).